### PR TITLE
Pass environment key to OpenAI adapter

### DIFF
--- a/app/modules/chat/infrastructure/chat_provider_selector.py
+++ b/app/modules/chat/infrastructure/chat_provider_selector.py
@@ -1,14 +1,29 @@
+import os
+
 from app.core.adapters.openai_adapter import OpenAIAdapter
 from app.core.adapters.vertex_adapter import VertexAIAdapter
 from app.core.adapters.ollama_adapter import OllamaAdapter
 from app.core.builder.prompt_builder import LLMPromptBuilder
+from app.core.loader import load_config
 
 def get_resilient_provider(prompt: str):
     builder = LLMPromptBuilder().set_prompt(prompt).auto_configure_from_prompt()
-    try: return OpenAIAdapter(), builder.build_openai()
-    except: pass
-    try: return VertexAIAdapter(), builder.build_gemini()
-    except: pass
-    try: return OllamaAdapter(), builder.build_ollama()
-    except: pass
+
+    api_key = os.getenv("OPENAI_API_KEY") or load_config().get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+    try:
+        return OpenAIAdapter(api_key), builder.build_openai()
+    except Exception:
+        pass
+    try:
+        return VertexAIAdapter(), builder.build_gemini()
+    except Exception:
+        pass
+    try:
+        return OllamaAdapter(), builder.build_ollama()
+    except Exception:
+        pass
+
     raise RuntimeError("All LLM providers failed.")


### PR DESCRIPTION
## Summary
- pass `OPENAI_API_KEY` to `OpenAIAdapter`
- error clearly when `OPENAI_API_KEY` is missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68425b65d9c4832a8aa40c89aa3a8fba